### PR TITLE
A faster and smaller binary parser and protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- 0.10
+  - 0.10
 notifications:
   irc: irc.freenode.org##socket.io
 env:

--- a/binary.js
+++ b/binary.js
@@ -1,0 +1,142 @@
+/**
+ * Modle requirements
+ */
+
+var isArray = require('isarray');
+
+/**
+ * Replaces every Buffer | ArrayBuffer in packet with a numbered placeholder.
+ * Anything with blobs or files should be fed through removeBlobs before coming
+ * here.
+ *
+ * @param {Object} packet - socket.io event packet
+ * @return {Object} with deconstructed packet and list of buffers
+ * @api public
+ */
+
+exports.deconstructPacket = function(packet) {
+    var buffers = [];
+    var packetData = packet.data;
+
+    function deconstructBinPackRecursive(data) {
+        if (!data) return data;
+
+        if ((global.Buffer && Buffer.isBuffer(data)) ||
+            (global.ArrayBuffer && data instanceof ArrayBuffer)) { // replace binary
+            var placeholder = {_placeholder: true, num: buffers.length};
+            buffers.push(data);
+            return placeholder;
+        } else if (isArray(data)) {
+            var newData = new Array(data.length);
+            for (var i = 0; i < data.length; i++) {
+                newData[i] = deconstructBinPackRecursive(data[i]);
+            }
+            return newData;
+        } else if ('object' == typeof data) {
+            var newData = {};
+            for (var key in data) {
+                newData[key] = deconstructBinPackRecursive(data[key]);
+            }
+            return newData;
+        }
+        return data;
+    }
+
+    var pack = packet;
+    pack.data = deconstructBinPackRecursive(packetData);
+    pack.attachments = buffers.length; // number of binary 'attachments'
+    return {packet: pack, buffers: buffers};
+}
+
+/**
+ * Reconstructs a binary packet from its placeholder packet and buffers
+ *
+ * @param {Object} packet - event packet with placeholders
+ * @param {Array} buffers - binary buffers to put in placeholder positions
+ * @return {Object} reconstructed packet
+ * @api public
+ */
+
+ exports.reconstructPacket = function(packet, buffers) {
+    var curPlaceHolder = 0;
+
+    function reconstructBinPackRecursive(data) {
+        if (data._placeholder) {
+            var buf = buffers[data.num]; // appropriate buffer (should be natural order anyway)
+            return buf;
+        } else if (isArray(data)) {
+            for (var i = 0; i < data.length; i++) {
+                data[i] = reconstructBinPackRecursive(data[i]);
+            }
+            return data;
+        } else if ('object' == typeof data) {
+            for (var key in data) {
+                data[key] = reconstructBinPackRecursive(data[key]);
+            }
+            return data;
+        }
+        return data;
+    }
+
+    packet.data = reconstructBinPackRecursive(packet.data);
+    packet.attachments = undefined; // no longer useful
+    return packet;
+ }
+
+/**
+ * Asynchronously removes Blobs or Files from data via
+ * FileReader's readAsArrayBuffer method. Used before encoding
+ * data as msgpack. Calls callback with the blobless data.
+ *
+ * @param {Object} data
+ * @param {Function} callback
+ * @api private
+ */
+
+exports.removeBlobs = function(data, callback) {
+
+  function removeBlobsRecursive(obj, curKey, containingObject) {
+    if (!obj) return obj;
+
+    // convert any blob
+    if ((global.Blob && obj instanceof Blob) ||
+        (global.File && obj instanceof File)) {
+      pendingBlobs++;
+
+      // async filereader
+      var fileReader = new FileReader();
+      fileReader.onload = function() { // this.result == arraybuffer
+        if (containingObject) {
+          containingObject[curKey] = this.result;
+        }
+        else {
+          bloblessData = this.result;
+        }
+
+        // if nothing pending its callback time
+        if(! --pendingBlobs) {
+          callback(bloblessData);
+        }
+      };
+
+      fileReader.readAsArrayBuffer(obj); // blob -> arraybuffer
+    }
+
+    if (isArray(obj)) { // handle array
+      for (var i = 0; i < obj.length; i++) {
+        removeBlobsRecursive(obj[i], i, obj);
+      }
+    } else if (obj && 'object' == typeof obj) { // and object
+      for (var key in obj) {
+        removeBlobsRecursive(obj[key], key, obj);
+      }
+    }
+  }
+
+  var pendingBlobs = 0;
+  var bloblessData = data;
+  removeBlobsRecursive(bloblessData);
+  if (!pendingBlobs) {
+    callback(bloblessData);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,16 +6,10 @@
     "type": "git",
     "url": "https://github.com/LearnBoost/socket.io-parser.git"
   },
-  "browser": {
-    "msgpack-js": "msgpack-allbrowsers"
-  },
   "dependencies": {
     "debug": "0.7.4",
-    "msgpack-js": "0.3.0",
     "json3": "3.2.6",
-    "isarray": "0.0.1",
-    "base64-js": "0.0.6",
-    "msgpack-allbrowsers": "0.0.1"
+    "isarray": "0.0.1"
   },
   "devDependencies": {
     "mocha": "1.16.2",

--- a/test/arraybuffer.js
+++ b/test/arraybuffer.js
@@ -12,26 +12,16 @@ describe('parser', function() {
       id: 0,
       nsp: '/'
     };
-    parser.encode(packet, function(encodedData) {
-      var decodedPacket = parser.decode(encodedData);
-      helpers.testPacketMetadata(packet, decodedPacket);
-      helpers.testArrayBuffers(packet.data, decodedPacket.data);
-    });
+    helpers.test_bin(packet);
   });
 
-  it('encodes an ArrayBuffer deep in JSON', function() {
+  it('encodes ArrayBuffers deep in JSON', function() {
     var packet = {
       type: parser.BINARY_EVENT,
-      data: {a: 'hi', b: {why: new ArrayBuffer(3)}, c:'bye'},
+      data: {a: 'hi', b: {why: new ArrayBuffer(3)}, c: {a: 'bye', b: { a: new ArrayBuffer(6)}}},
       id: 999,
       nsp: '/deep'
     };
-    parser.encode(packet, function(encodedData) {
-      var decodedPacket = parser.decode(encodedData);
-      helpers.testPacketMetadata(packet, decodedPacket);
-      expect(packet.data.a).to.eql(decodedPacket.data.a);
-      expect(packet.data.c).to.eql(decodedPacket.data.c);
-      helpers.testArrayBuffers(packet.data.b.why, decodedPacket.data.b.why);
-    });
+    helpers.test_bin(packet);
   });
 });

--- a/test/blob.js
+++ b/test/blob.js
@@ -16,17 +16,14 @@ describe('parser', function() {
     } else {
       data = new Blob([new ArrayBuffer(2)]);
     }
+
     var packet = {
       type: parser.BINARY_EVENT,
       data: data,
       id: 0,
       nsp: '/'
     };
-    parser.encode(packet, function(encodedData) {
-      var decodedPacket = parser.decode(encodedData);
-      helpers.testPacketMetadata(packet, decodedPacket);
-      helpers.testArrayBuffers(packet.data, decodedPacket.data);
-    });
+    helpers.test_bin(packet);
   });
 
   it('encodes an Blob deep in JSON', function() {
@@ -45,13 +42,7 @@ describe('parser', function() {
       id: 999,
       nsp: '/deep'
     };
-    parser.encode(packet, function(encodedData) {
-      var decodedPacket = parser.decode(encodedData);
-      helpers.testPacketMetadata(packet, decodedPacket);
-      expect(packet.data.a).to.eql(decodedPacket.data.a);
-      expect(packet.data.c).to.eql(decodedPacket.data.c);
-      helpers.testArrayBuffers(packet.data.b.why, decodedPacket.data.b.why);
-    });
+    helpers.test_bin(packet);
   });
 
 });

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -6,7 +6,7 @@ var decode = parser.decode;
 
 describe('parser', function() {
   it('encodes a Buffer', function() {
-      helpers.test({
+      helpers.test_bin({
         type: parser.BINARY_EVENT,
         data: new Buffer('abc', 'utf8'),
         id: 23,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -3,19 +3,36 @@ var expect = require('expect.js');
 var encode = parser.encode;
 var decode = parser.decode;
 
-// tests encoding and decoding a packet
+// tests encoding and decoding a single packet
 module.exports.test = function(obj){
-  encode(obj, function(encodedPacket) {
-    expect(decode(encodedPacket)).to.eql(obj);
+  encode(obj, function(encodedPackets) {
+    expect(decode(encodedPackets[0])).to.eql(obj);
+  });
+}
+
+// tests encoding of binary packets
+module.exports.test_bin = function test_bin(obj) {
+  var originalData = obj.data;
+  encode(obj, function(encodedPackets) {
+    var reconPack = decode(encodedPackets[0]);
+    var reconstructor = new parser.BinaryReconstructor(reconPack);
+    var packet;
+    for (var i = 1; i < encodedPackets.length; i++) {
+      packet = reconstructor.takeBinaryData(encodedPackets[i]);
+    }
+
+    obj.data = originalData;
+    obj.attachments = undefined;
+    expect(obj).to.eql(packet);
   });
 }
 
 // array buffer's slice is native code that is not transported across
 // socket.io via msgpack, so regular .eql fails
 module.exports.testArrayBuffers = function(buf1, buf2) {
-  buf1.slice = undefined;
-  buf2.slice = undefined;
-  expect(buf1).to.eql(buf2);
+   buf1.slice = undefined;
+   buf2.slice = undefined;
+   expect(buf1).to.eql(buf2);
 }
 
 module.exports.testPacketMetadata = function(p1, p2) {


### PR DESCRIPTION
This is a squash of a few commits. Below is a small summary of commits.

Results from it: before the build size of socket.io-client was ~250K.
Now it is ~215K.
Tests I was doing here
(https://github.com/kevin-roark/socketio-binaryexample/tree/speed-testing)
take about 1/4 - 1/5 as long with this commit compared to msgpack.

The first was the initial rewrite of the encoding, which removes msgpack
and instead uses a sequence of engine.write's for a binary event. The
first write is the packet metadata with placeholders in the json for
any binary data. Then the following events are the raw binary data that
get filled by the placeholders.

The second commit was bug fixes that made the tests pass.

The third commit was removing unnecssary packages from package.json.

Fourth commit was adding nice comments, and 5th commit was merging
upstream.

The remaining commits involved merging with actual socket.io-parser,
rather than the protocol repository. Oops.
