### PR TITLE
Protocol is now class-based

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "debug": "0.7.4",
     "json3": "3.2.6",
+    "emitter": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
     "isarray": "0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Separated the encoding and decoding into two public-facing objects,
Encoder and Decoder.

Both objects take nothing on construction. Encoder has a single method,
encode, that mimics the previous version's function encode (takes a
packet object and a callback). Decoder has a single method too, add, that
takes any object (packet string or binary data). Decoder emits a 'decoded'
event when it has received all of the parts of a packet. The only
parameter for the decoded event is the reconstructed packet.

I am hesitant about the Encoder.encode vs Decoder.add thing. Should it be
more consistent, or should it stay like this where the function names are
more descriptive?

Also, rewrote the test helper functions to deal with new event-based
decoding. Wrote a new test in test/arraybuffer.js that tests for memory
leaks in Decoder as well.
