### PR TITLE
Fix/remove blob object check

### DIFF
--- a/binary.js
+++ b/binary.js
@@ -3,7 +3,6 @@
  */
 
 var isArray = require('isarray');
-var hasBin = require('has-binary-data');
 
 /**
  * Replaces every Buffer | ArrayBuffer in packet with a numbered placeholder.
@@ -127,7 +126,7 @@ exports.removeBlobs = function(data, callback) {
       for (var i = 0; i < obj.length; i++) {
         removeBlobsRecursive(obj[i], i, obj);
       }
-    } else if (obj && 'object' == typeof obj && !hasBin(obj)) { // and object
+    } else if (obj && 'object' == typeof obj && !isBuf(obj)) { // and object
       for (var key in obj) {
         removeBlobsRecursive(obj[key], key, obj);
       }
@@ -140,4 +139,14 @@ exports.removeBlobs = function(data, callback) {
   if (!pendingBlobs) {
     callback(bloblessData);
   }
+}
+
+/**
+ * Returns true if obj is a buffer or an arraybuffer.
+ *
+ * @api private
+ */
+function isBuf(obj) {
+  return (global.Buffer && Buffer.isBuffer(obj)) ||
+         (global.ArrayBuffer && obj instanceof ArrayBuffer);
 }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "debug": "0.7.4",
     "json3": "3.2.6",
     "emitter": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
-    "isarray": "0.0.1",
-    "has-binary-data": "0.1.0"
+    "isarray": "0.0.1"
   },
   "devDependencies": {
     "mocha": "1.16.2",


### PR DESCRIPTION
There was in issue in binary.removeBlobs where when recursively iterating over objects it was checking each byte in an array buffer or buffer for the presence of blobs. Oops.

Added a check so that binary data is not iterated over like a regular object.
