### PR TITLE
Encoding ack packets as binary

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,16 +80,6 @@ exports.ERROR = 4;
 
 exports.BINARY_EVENT = 5;
 
-/**
- * Set of types to encode and decode in binary-style.
- *
- * @api private
- */
-
-var binaryEncodeTypes = {};
-binaryEncodeTypes[exports.BINARY_EVENT] = true;
-binaryEncodeTypes[exports.ACK] = true;
-
 exports.Encoder = Encoder
 
 /**
@@ -112,7 +102,7 @@ function Encoder() {};
 Encoder.prototype.encode = function(obj, callback){
   debug('encoding packet %j', obj);
 
-  if (obj.type in binaryEncodeTypes) {
+  if (exports.BINARY_EVENT == obj.type || exports.ACK == obj.type) {
     encodeAsBinary(obj, callback);
   }
   else {
@@ -137,7 +127,7 @@ function encodeAsString(obj) {
   str += obj.type;
 
   // attachments if we have them
-  if (obj.type in binaryEncodeTypes) {
+  if (exports.BINARY_EVENT == obj.type || exports.ACK == obj.type) {
     str += obj.attachments;
     str += '-';
   }
@@ -223,7 +213,7 @@ Decoder.prototype.add = function(obj) {
   var packet;
   if ('string' == typeof obj) {
     packet = decodeString(obj);
-    if (packet.type in binaryEncodeTypes) { // binary packet's json
+    if (exports.BINARY_EVENT == packet.type || exports.ACK == packet.type) { // binary packet's json
       this.reconstructor = new BinaryReconstructor(packet);
 
       // no attachments, labeled binary but no binary data to follow
@@ -269,7 +259,7 @@ function decodeString(str) {
   if (null == exports.types[p.type]) return error();
 
   // look up attachments if type binary
-  if (p.type in binaryEncodeTypes) {
+  if (exports.BINARY_EVENT == p.type || exports.ACK == p.type) {
     p.attachments = '';
     while (str.charAt(++i) != '-') {
       p.attachments += str.charAt(i);


### PR DESCRIPTION
So that arbitrary data can be passed back and forth in ack callbacks.

Discovered that this might be desirable when writing tests for socket.io. Logic was -- why would a user not expect arbitrary data to work in callback ack functions? Now you can put buffers, etc in there ack callbacks and it works fine.

A consequence of this is that all ack packets are encoded in binary style now -- if they don't have binary data then this is maybe roundabout, but I figured that was better than adding another packet type (BINARY_ACK)? let me know
