### PR TITLE
fix null reconstruction bug

### DIFF
--- a/binary.js
+++ b/binary.js
@@ -61,7 +61,7 @@ exports.deconstructPacket = function(packet) {
     var curPlaceHolder = 0;
 
     function reconstructBinPackRecursive(data) {
-        if (data._placeholder) {
+        if (data && data._placeholder) {
             var buf = buffers[data.num]; // appropriate buffer (should be natural order anyway)
             return buf;
         } else if (isArray(data)) {
@@ -69,7 +69,7 @@ exports.deconstructPacket = function(packet) {
                 data[i] = reconstructBinPackRecursive(data[i]);
             }
             return data;
-        } else if ('object' == typeof data) {
+        } else if (data && 'object' == typeof data) {
             for (var key in data) {
                 data[key] = reconstructBinPackRecursive(data[key]);
             }

--- a/test/arraybuffer.js
+++ b/test/arraybuffer.js
@@ -24,6 +24,16 @@ describe('parser', function() {
     helpers.test_bin(packet);
   });
 
+  it('encodes deep binary JSON with null values', function() {
+    var packet = {
+      type: parser.BINARY_EVENT,
+      data: {a: 'b', c: 4, e: {g: null}, h: new ArrayBuffer(9)},
+      nsp: '/',
+      id: 600
+    }
+    helpers.test_bin(packet);
+  });
+
   it('cleans itself up on close', function() {
     var packet = {
       type: parser.BINARY_EVENT,


### PR DESCRIPTION
previously could not encode packets with null and binary mixed values. Oops stupid bug.

Added a test as well.

client and server should ideally reference this soon :)
