### PR TITLE
don't iterate keys of date objects

### DIFF
--- a/binary.js
+++ b/binary.js
@@ -32,7 +32,7 @@ exports.deconstructPacket = function(packet) {
                 newData[i] = deconstructBinPackRecursive(data[i]);
             }
             return newData;
-        } else if ('object' == typeof data) {
+        } else if ('object' == typeof data && !(data instanceof Date)) {
             var newData = {};
             for (var key in data) {
                 newData[key] = deconstructBinPackRecursive(data[key]);


### PR DESCRIPTION
This way we don't try to iterate keys for date objects. Addresses https://github.com/LearnBoost/socket.io/issues/1518.
