### PR TITLE
Upgrade component-emitter to 1.1.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 var debug = require('debug')('socket.io-parser');
 var json = require('json3');
 var isArray = require('isarray');
-var Emitter = require('emitter');
+var Emitter = require('component-emitter');
 var binary = require('./binary');
 
 /**

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "debug": "0.7.4",
     "json3": "3.2.6",
-    "emitter": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
+    "component-emitter": "1.1.2",
     "isarray": "0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Switch from depending on a tarball URL to the published
component-emitter package at its latest version.

Change all references to emitter module to the new
component-emitter name.

Related: Automattic/engine.io-client#305
