### PR TITLE
Use matrix and update zuul

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,38 @@ env:
   global:
   - secure: 28HHk1J0H64KNjzmmlxG/Ro0EPuLnhO0rU+kZjjthDHj/FaugIsqjAVQ1Dl6heWV2/MlVzw6nDCyMNiGwiVk0ruZPQ0SYdAKLplrdMtzAihbU3xx+ULFQPLM3SoW0ZFCEpe8dWPGy4WdgW7aLByeel9TJb3vlhAu7p7AvrcO7Fs=
   - secure: rKEG0Cfw0vkw8thk63RHYG7h8XWYcBlvZ0w1IWpr2dAfnnLMi1palSTrBrFQc77flk7rN00zGIe76FhKydV9r4WWYAUYKPqo4k+9/FkpzjZlNtL49QRoNwC9jmJ8OeUwGowA13gZPyl/5P13wVaKCB0YrKnzz5LHo3Sp7So6J8U=
+matrix:
+  include:
+    - node_js: '0.10'
+      env: BROWSER_NAME=chrome BROWSER_VERSION=latest
+    - node_js: '0.10'
+      env: BROWSER_NAME=firefox BROWSER_VERSION=latest
+    - node_js: '0.10'
+      env: BROWSER_NAME=safari BROWSER_VERSION=latest
+    - node_js: '0.10'
+      env: BROWSER_NAME=ie BROWSER_VERSION=10 BROWSER_PLATFORM="Windows 2012"
+    - node_js: '0.10'
+      env: BROWSER_NAME=ie BROWSER_VERSION=6
+    - node_js: '0.10'
+      env: BROWSER_NAME=ie BROWSER_VERSION=7
+    - node_js: '0.10'
+      env: BROWSER_NAME=ie BROWSER_VERSION=8
+    - node_js: '0.10'
+      env: BROWSER_NAME=ie BROWSER_VERSION=9
+    - node_js: '0.10'
+      env: BROWSER_NAME=ie BROWSER_VERSION=latest
+    - node_js: '0.10'
+      env: BROWSER_NAME=iphone BROWSER_VERSION=4.3
+    - node_js: '0.10'
+      env: BROWSER_NAME=iphone BROWSER_VERSION=5.1
+    - node_js: '0.10'
+      env: BROWSER_NAME=iphone BROWSER_VERSION=6.0
+    - node_js: '0.10'
+      env: BROWSER_NAME=iphone BROWSER_VERSION=6.1
+    - node_js: '0.10'
+      env: BROWSER_NAME=iphone BROWSER_VERSION=7.0
+    - node_js: '0.10'
+      env: BROWSER_NAME=iphone BROWSER_VERSION=7.1
+    - node_js: '0.10'
+      env: BROWSER_NAME=iphone BROWSER_VERSION=8.0
+

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,4 +1,8 @@
 ui: mocha-bdd
+tunnel:
+  type: ngrok
+  authtoken: JnawIksKFkXQzrxSjIjQ
+  proto: tcp
 browsers: 
   - name: chrome
     version: 29..latest

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,26 @@
-
 REPORTER = dot
 
 test:
+	@if [ "x$(BROWSER_NAME)" = "x" ]; then make test-node; else make test-zuul; fi
+
+test-node:
 	@./node_modules/.bin/mocha \
 		--reporter $(REPORTER) \
-		--bail \
 		test/index.js
-	@./node_modules/.bin/zuul -- test/index.js
+
+test-zuul:
+	@if [ "x$(BROWSER_PLATFORM)" = "x" ]; then \
+		./node_modules/zuul/bin/zuul \
+		--browser-name $(BROWSER_NAME) \
+		--browser-version $(BROWSER_VERSION) \
+		test/index.js; \
+		else \
+		./node_modules/zuul/bin/zuul \
+		--browser-name $(BROWSER_NAME) \
+		--browser-version $(BROWSER_VERSION) \
+		--browser-platform "$(BROWSER_PLATFORM)" \
+		test/index.js; \
+	fi
 
 .PHONY: test
+

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "devDependencies": {
     "mocha": "1.16.2",
     "expect.js": "0.2.0",
-    "zuul": "1.6.3"
+    "zuul": "1.18.0",
+    "zuul-ngrok": "2.0.0"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
Use travis matrix for nicer build.

Updated zuul to get code coverage in-browser and for official ngrok support through pluggable tunnels.