### PR TITLE
Fix order of types array

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,10 +28,10 @@ exports.types = [
   'CONNECT',
   'DISCONNECT',
   'EVENT',
-  'BINARY_EVENT',
   'ACK',
-  'BINARY_ACK',
   'ERROR'
+  'BINARY_EVENT',
+  'BINARY_ACK',
 ];
 
 /**


### PR DESCRIPTION
There is a public types array with the name of the different types, but this didn't correspond with the constants that exist per type.
I'm assuming nobody currently uses this types array outside of the parser, even though it's public. 