### PR TITLE
Reduce npm package

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@
 
 var debug = require('debug')('socket.io-parser');
 var json = require('json3');
-var isArray = require('isarray');
 var Emitter = require('component-emitter');
 var binary = require('./binary');
 var isBuf = require('./is-buffer');

--- a/package.json
+++ b/package.json
@@ -2,18 +2,23 @@
   "name": "socket.io-parser",
   "version": "2.2.6",
   "description": "socket.io protocol parser",
+  "files": [
+    "index.js",
+    "binary.js",
+    "is-buffer.js"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/Automattic/socket.io-parser.git"
   },
   "dependencies": {
-    "debug": "2.2.0",
-    "json3": "3.3.2",
-    "component-emitter": "1.1.2",
-    "isarray": "0.0.1",
-    "benchmark": "1.0.0"
+    "component-emitter": "^1.2.0",
+    "debug": "^2.2.0",
+    "isarray": "^1.0.0",
+    "json3": "^3.3.2"
   },
   "devDependencies": {
+    "benchmark": "1.0.0",
     "mocha": "1.16.2",
     "expect.js": "0.2.0",
     "zuul": "3.7.3",


### PR DESCRIPTION
Hi. You have useless benchmark in published module. [A few words about versioning](https://github.com/postcss/postcss/issues/312)

And do you still need `isBuf` and `isarray` modules? I think `Array.isArray` and `Buffer.isBuffer` api is stable.