### PR TITLE
fix Blob detection for iOS 8/9

### DIFF
--- a/binary.js
+++ b/binary.js
@@ -6,6 +6,9 @@
 
 var isArray = require('isarray');
 var isBuf = require('./is-buffer');
+var toString = Object.prototype.toString;
+var withNativeBlob = typeof global.Blob === 'function' || toString.call(global.Blob) === '[object BlobConstructor]';
+var withNativeFile = typeof global.File === 'function' || toString.call(global.File) === '[object FileConstructor]';
 
 /**
  * Replaces every Buffer | ArrayBuffer in packet with a numbered placeholder.
@@ -97,8 +100,8 @@ exports.removeBlobs = function(data, callback) {
     if (!obj) return obj;
 
     // convert any blob
-    if ((typeof global.Blob === 'function' && obj instanceof Blob) ||
-        (typeof global.File === 'function' && obj instanceof File)) {
+    if ((withNativeBlob && obj instanceof Blob) ||
+        (withNativeFile && obj instanceof File)) {
       pendingBlobs++;
 
       // async filereader


### PR DESCRIPTION
`typeof global.Blob !== 'function'` in iOS 8/9 (https://travis-ci.org/socketio/socket.io-parser/jobs/225403654)

