### PR TITLE
actually throw on protocol violations

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,7 +272,9 @@ function decodeString(str) {
     type: Number(str.charAt(0))
   };
 
-  if (null == exports.types[p.type]) return error();
+  if (exports.types[p.type] === null) {
+    throw new Error('unknown packet type');
+  }
 
   // look up attachments if type binary
   if (exports.BINARY_EVENT === p.type || exports.BINARY_ACK === p.type) {
@@ -318,20 +320,11 @@ function decodeString(str) {
 
   // look up json data
   if (str.charAt(++i)) {
-    p = tryParse(p, str.substr(i));
+    p.data = JSON.parse(str.substr(i));
   }
 
   debug('decoded %s as %j', str, p);
   return p;
-}
-
-function tryParse(p, str) {
-  try {
-    p.data = JSON.parse(str);
-  } catch(e){
-    return error();
-  }
-  return p; 
 }
 
 /**
@@ -391,10 +384,3 @@ BinaryReconstructor.prototype.finishedReconstruction = function() {
   this.reconPack = null;
   this.buffers = [];
 };
-
-function error() {
-  return {
-    type: exports.ERROR,
-    data: 'parser error'
-  };
-}

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,8 +1,6 @@
 var parser = require('../index.js');
 var expect = require('expect.js');
 var helpers = require('./helpers.js');
-var encode = parser.encode;
-var decode = parser.decode;
 
 describe('parser', function(){
 
@@ -56,6 +54,15 @@ describe('parser', function(){
       var decoder = new parser.Decoder();
       decoder.add('5');
     } catch(e){
+      expect(e.message).to.match(/Illegal/);
+    }
+  });
+
+  it('should throw when decoding an invalid packet', function(){
+    try {
+      var decoder = new parser.Decoder();
+      decoder.add('442["some","data","that","breaks","stuff"]');
+    } catch (e) {
       expect(e.message).to.match(/Illegal/);
     }
   });


### PR DESCRIPTION
That change makes the parser throw when a packet cannot be decoded properly. The exception is then
caught by the server, which closes the connection.

Related: https://github.com/socketio/socket.io/issues/3036