### PR TITLE
Catch JSON.stringfy exceptions instead of silent failing

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,8 +132,7 @@ Encoder.prototype.encode = function(obj, callback){
 
   if (exports.BINARY_EVENT === obj.type || exports.BINARY_ACK === obj.type) {
     encodeAsBinary(obj, callback);
-  }
-  else {
+  } else {
     var encoding = encodeAsString(obj);
     callback([encoding]);
   }
@@ -170,7 +169,11 @@ function encodeAsString(obj) {
 
   // json data
   if (null != obj.data) {
-    str += JSON.stringify(obj.data);
+    try {
+      str += JSON.stringify(obj.data);
+    } catch (error) {
+      return error();      
+    }
   }
 
   debug('encoded %j as %s', obj, str);

--- a/test/parser.js
+++ b/test/parser.js
@@ -51,6 +51,18 @@ describe('parser', function(){
     });
   });
 
+  it('encodes a circular object (return error)', function() {
+    var john = new Object();  
+    var mary = new Object();  
+    john.sister = mary;  
+    mary.brother = john;
+
+    var encoder = new parser.Encoder();
+    encode.encode(john, function(encodedPackets) {
+      expect(encodedPackets[0].type).to.be(parser.ERROR);
+    });
+  });
+
   it('decodes a bad binary packet', function(){
     try {
       var decoder = new parser.Decoder();


### PR DESCRIPTION
This PR is to respond issue #3125 in the main socket.io project: https://github.com/socketio/socket.io/issues/3125.

When JSON.stringfy throws exceptions, `encodeAsString` would fail silently and hang the channel, as described in the original issue. We will now return the standard error object when an exception is thrown, such that encoding errors can be properly handled.
