### PR TITLE
Enable circular references when serializing JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
  */
 
 var debug = require('debug')('socket.io-parser');
+var CircularJSON = require('circular-json');
 var Emitter = require('component-emitter');
 var hasBin = require('has-binary2');
 var binary = require('./binary');
@@ -170,7 +171,7 @@ function encodeAsString(obj) {
 
   // json data
   if (null != obj.data) {
-    str += JSON.stringify(obj.data);
+    str += CircularJSON.stringify(obj.data);
   }
 
   debug('encoded %j as %s', obj, str);
@@ -327,7 +328,7 @@ function decodeString(str) {
 
 function tryParse(p, str) {
   try {
-    p.data = JSON.parse(str);
+    p.data = CircularJSON.parse(str);
   } catch(e){
     return error();
   }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "is-buffer.js"
   ],
   "dependencies": {
-    "debug": "~2.6.4",
+    "circular-json": "^0.4.0",
     "component-emitter": "1.2.1",
+    "debug": "~2.6.4",
     "has-binary2": "~1.0.2",
     "isarray": "2.0.1"
   },


### PR DESCRIPTION
As previously asked on circular-json repository [1],
this PR would like to bring the heavily battle tested
circular-json module as parser, enabling circular references
to travel over the socket.

Thanks for considering this change.

[1] https://github.com/WebReflection/circular-json/issues/38#issuecomment-347716379