### PR TITLE
[fix] Use ArrayBuffer.isView to check for typed arrays

### DIFF
--- a/is-buffer.js
+++ b/is-buffer.js
@@ -9,5 +9,5 @@ module.exports = isBuf;
 
 function isBuf(obj) {
   return (global.Buffer && global.Buffer.isBuffer(obj)) ||
-         (global.ArrayBuffer && obj instanceof ArrayBuffer);
+         (global.ArrayBuffer && (obj instanceof ArrayBuffer || ArrayBuffer.isView(obj)));
 }


### PR DESCRIPTION
Related: https://github.com/socketio/socket.io/issues/3143