### PR TITLE
[fix] Properly detect typed arrays (#82)

### DIFF
--- a/is-buffer.js
+++ b/is-buffer.js
@@ -1,6 +1,17 @@
 
 module.exports = isBuf;
 
+var withNativeBuffer = typeof global.Buffer === 'function' && typeof global.Buffer.isBuffer === 'function';
+var withNativeArrayBuffer = typeof global.ArrayBuffer === 'function';
+
+var isView = (function () {
+  if (typeof global.ArrayBuffer.isView === 'function') {
+    return global.ArrayBuffer.isView;
+  } else {
+    return function (obj) { return obj.buffer instanceof global.ArrayBuffer; };
+  }
+})();
+
 /**
  * Returns true if obj is a buffer or an arraybuffer.
  *
@@ -8,6 +19,6 @@ module.exports = isBuf;
  */
 
 function isBuf(obj) {
-  return (global.Buffer && global.Buffer.isBuffer(obj)) ||
-         (global.ArrayBuffer && (obj instanceof ArrayBuffer || ArrayBuffer.isView(obj)));
+  return (withNativeBuffer && global.Buffer.isBuffer(obj)) ||
+          (withNativeArrayBuffer && (obj instanceof global.ArrayBuffer || isView(obj)));
 }

--- a/test/arraybuffer.js
+++ b/test/arraybuffer.js
@@ -14,6 +14,19 @@ describe('parser', function() {
     helpers.test_bin(packet);
   });
 
+  it('encodes a TypedArray', function() {
+    var array = new Uint8Array(5);
+    for (var i = 0; i < array.length; i++) array[i] = i;
+
+    var packet = {
+      type: parser.BINARY_EVENT,
+      data: ['a', array],
+      id: 0,
+      nsp: '/'
+    };
+    helpers.test_bin(packet);
+  });
+
   it('encodes ArrayBuffers deep in JSON', function() {
     var packet = {
       type: parser.BINARY_EVENT,


### PR DESCRIPTION
ArrayBuffer.isView method is not defined in IE10.