### PR TITLE
[chore] Bump debug to version 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "is-buffer.js"
   ],
   "dependencies": {
-    "debug": "~3.1.0",
+    "debug": "~4.1.0",
     "component-emitter": "1.2.1",
     "isarray": "2.0.1"
   },


### PR DESCRIPTION
Syncing the version of debug throughout the repositories.
https://github.com/socketio/engine.io-client/pull/612
https://github.com/socketio/engine.io/pull/581
https://github.com/socketio/socket.io-client/pull/1304
https://github.com/socketio/socket.io-emitter/pull/82
https://github.com/socketio/socket.io-redis/pull/306