### PR TITLE
WIP: additional Payload data from socket.io response.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 [![Build Status](https://secure.travis-ci.org/socketio/socket.io-parser.svg?branch=master)](http://travis-ci.org/socketio/socket.io-parser)
 [![NPM version](https://badge.fury.io/js/socket.io-parser.svg)](http://badge.fury.io/js/socket.io-parser)
 
-A socket.io encoder and decoder written in JavaScript complying with version `3`
+A socket.io encoder and decoder written in JavaScript complying with version `4`
 of [socket.io-protocol](https://github.com/socketio/socket.io-protocol).
 Used by [socket.io](https://github.com/automattic/socket.io) and
 [socket.io-client](https://github.com/automattic/socket.io-client).

--- a/index.js
+++ b/index.js
@@ -116,6 +116,13 @@ function Encoder() {}
 var ERROR_PACKET = exports.ERROR + '"encode error"';
 
 /**
+ * Store extra response from Socket.io packet.
+ *
+ * @type {string}
+ */
+exports.extraMessageResponse = '';
+
+/**
  * Encode a packet as a single string if non-binary, or as a
  * buffer sequence, depending on packet type.
  *
@@ -248,6 +255,12 @@ Decoder.prototype.add = function(obj) {
         this.emit('decoded', packet);
       }
     } else { // non-binary full packet
+      if (typeof packet.data !== 'undefined') {
+        let extraMessageResponse = typeof Object.entries(packet.data)[2] !== 'undefined' ? Object.entries(packet.data)[2] : {};
+        if (typeof Object.values(extraMessageResponse)[1] === 'string') {
+          exports.extraMessageResponse = Object.values(extraMessageResponse)[1];
+        }
+      }
       this.emit('decoded', packet);
     }
   } else if (isBuf(obj) || obj.base64) { // raw binary data

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socket.io-parser",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "socket.io protocol parser",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "is-buffer.js"
   ],
   "dependencies": {
-    "debug": "~3.1.0",
+    "debug": "~4.1.0",
     "component-emitter": "1.2.1",
     "isarray": "2.0.1"
   },


### PR DESCRIPTION
store additional payload from socket.io response if available and export that var for use in `artillery.io/core/lib/engine_socketio.js` and `artillery.io/core/lib/engine_until.js`.

makes the additional payload data available in the response.