### PR TITLE
fix: move @types/component-emitter to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -911,8 +911,7 @@
     "@types/component-emitter": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
-      "integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg==",
-      "dev": true
+      "integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
     },
     "@types/debug": {
       "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "component-emitter": "~1.3.0",
+    "@types/component-emitter": "^1.2.10",
     "debug": "~4.1.0"
   },
   "devDependencies": {
     "@babel/core": "~7.9.6",
     "@babel/preset-env": "~7.9.6",
-    "@types/component-emitter": "^1.2.10",
     "@types/debug": "^4.1.5",
     "@types/node": "^14.11.1",
     "babelify": "~10.0.0",


### PR DESCRIPTION
Otherwise consumers of socket.io-parser (and socket.io) need to have it listed in their devDependencies.

While doing this I noticed that `npm audit` reported a lot of issues. It might be worth to upgrade dependencies.

Signed-off-by: Pascal Sthamer <sthamer.pascal@gmail.com>