### PR TITLE
allows [Object: null prototype] in binary packet

### DIFF
--- a/lib/binary.ts
+++ b/lib/binary.ts
@@ -33,7 +33,7 @@ function _deconstructPacket(data, buffers) {
   } else if (typeof data === "object" && !(data instanceof Date)) {
     const newData = {};
     for (const key in data) {
-      if (data.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(data, key)) {
         newData[key] = _deconstructPacket(data[key], buffers);
       }
     }
@@ -68,7 +68,7 @@ function _reconstructPacket(data, buffers) {
     }
   } else if (typeof data === "object") {
     for (const key in data) {
-      if (data.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(data, key)) {
         data[key] = _reconstructPacket(data[key], buffers);
       }
     }

--- a/test/arraybuffer.js
+++ b/test/arraybuffer.js
@@ -14,6 +14,21 @@ describe("parser", () => {
     helpers.test_bin(packet, done);
   });
 
+  it("encodes an ArrayBuffer into an object with a null prototype", (done) => {
+    const packet = {
+      type: PacketType.EVENT,
+      data: [
+        "a",
+        Object.create(null, {
+          array: { value: new ArrayBuffer(2), enumerable: true },
+        }),
+      ],
+      id: 0,
+      nsp: "/",
+    };
+    helpers.test_bin(packet, done);
+  });
+
   it("encodes a TypedArray", (done) => {
     const array = new Uint8Array(5);
     for (let i = 0; i < array.length; i++) array[i] = i;


### PR DESCRIPTION
Hello,

I get the following error when trying to encode a binary packet with a null prototype object:

![socketio_parser_error](https://user-images.githubusercontent.com/55579499/153238003-26a19b68-124e-4660-8751-4f423664ffe8.png)

I think the solutions is to simply use the safer version of the call to `hasOwnProperty`, just like [here](https://github.com/socketio/socket.io-parser/blob/master/lib/is-binary.ts#L60).

Let me know what you think of it.